### PR TITLE
Fix for hang when stopping service

### DIFF
--- a/etc/picochess.service
+++ b/etc/picochess.service
@@ -8,6 +8,7 @@ Environment="XAUTHORITY=/home/pi/.Xauthority"
 Type=simple
 ExecStart=/usr/bin/python3 /opt/picochess/picochess.py
 ExecStop=/usr/bin/pkill -f picochess.py
+ExecStop=/usr/bin/pkill -9 -f mess
 WorkingDirectory=/opt/picochess/
 
 [Install]


### PR DESCRIPTION
When a MAME engine is running and the service is stopped, it will hang until the system forcibly kills the mess process. This change makes it immediate.