### PR TITLE
Fix Fischer Initial Clock Times

### DIFF
--- a/timecontrol.py
+++ b/timecontrol.py
@@ -123,7 +123,7 @@ class TimeControl(object):
             self.clock_time[chess.WHITE] = self.clock_time[chess.BLACK] = self.game_time * 60
 
         elif self.mode == TimeMode.FISCHER:
-            self.clock_time[chess.WHITE] = self.clock_time[chess.BLACK] = self.game_time * 60 + self.fisch_inc
+            self.clock_time[chess.WHITE] = self.clock_time[chess.BLACK] = self.game_time * 60
 
         elif self.mode == TimeMode.FIXED:
             self.clock_time[chess.WHITE] = self.clock_time[chess.BLACK] = self.move_time


### PR DESCRIPTION
Fischer clock times started with an initial increment added. This is wrong. Increment is only added after a move is made.